### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,4 +1,6 @@
 name: Test Release Workflow
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/vemikrs/jackson-databind-jsonc/security/code-scanning/4](https://github.com/vemikrs/jackson-databind-jsonc/security/code-scanning/4)

To address the problem, the workflow should specify the minimal permissions needed for the GITHUB_TOKEN in a `permissions` block. This can be added either at the top level of the workflow (recommended, as only one job is present) or for the specific job. Review of the workflow shows that the only external action requiring permissions is `actions/checkout` (for source code read access) and `actions/upload-artifact`. Neither requires special write privileges to GitHub resources; `contents: read` is sufficient. 

The best fix is to add a top-level `permissions` block immediately after the workflow name and before `on:`. Set `contents: read`, which is the least privilege needed for these steps. No further imports or code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
